### PR TITLE
String signer uses base64 for the signature encoding rather than UTF-8

### DIFF
--- a/src/main/java/com/ft/membership/crypto/signature/Encoder.java
+++ b/src/main/java/com/ft/membership/crypto/signature/Encoder.java
@@ -17,7 +17,7 @@ public class Encoder {
      */
     public static String getBase64EncodedString(final byte[] bytes) {
 
-        return new String(BASE_64_ENCODER.encode(bytes), StandardCharsets.UTF_8);
+        return BASE_64_ENCODER.encodeToString(bytes);
     }
 
     /**
@@ -29,7 +29,7 @@ public class Encoder {
     public static Optional<byte[]> getBase64DecodedBytes(final String encodedString) {
 
         try {
-            return Optional.of(BASE_64_DECODER.decode(encodedString.getBytes(StandardCharsets.UTF_8)));
+            return Optional.of(BASE_64_DECODER.decode(encodedString));
         } catch(IllegalArgumentException e) {
             // We do not want a RuntimeException to be thrown when the string passed is not in valid Base64 scheme
             // as bad input is possible to the lib methods.

--- a/src/test/java/com/ft/membership/crypto/signature/StringSignerTest.java
+++ b/src/test/java/com/ft/membership/crypto/signature/StringSignerTest.java
@@ -20,21 +20,21 @@ public class StringSignerTest {
 
     @Test
     public void shouldUTF8EncodeStringAndReturnSignatureAsUrlSafeBase64() throws UnsupportedEncodingException {
-        final String signature = "Signature as a string";
+        final String signature = "111222333444";
         final String stringToSign = "ユニコード文字列は署名します"; //using unicode to check UTF-8 encoding
 
         when(mockSigner.signBytes(stringToSign.getBytes("UTF-8")))
-                .thenReturn(signature.getBytes("UTF-8"));
+                .thenReturn(Encoder.getBase64DecodedBytes(signature).get());
 
         assertThat(stringSigner.signString(stringToSign), equalTo(signature));
     }
 
     @Test
     public void shouldUTF8EncodeStringAndVerifyAgainstBase64DecodedSignature() throws UnsupportedEncodingException {
-        final String signature = "Signature as a string";
+        final String signature = "111222333444";
         final String stringToSign = "ユニコード文字列は署名します"; //using unicode to check UTF-8 encoding
 
-        when(mockSigner.isSignatureValid(stringToSign.getBytes("UTF-8"), signature.getBytes("UTF-8")))
+        when(mockSigner.isSignatureValid(stringToSign.getBytes("UTF-8"), Encoder.getBase64DecodedBytes(signature).get()))
                 .thenReturn(true);
 
         assertThat(stringSigner.isSignatureValid(stringToSign, signature), equalTo(true));
@@ -43,10 +43,10 @@ public class StringSignerTest {
     @Test
     public void shouldUTF8EncodeStringAndFailToVerifyAgainstInvalidBase64DecodedSignature()
             throws UnsupportedEncodingException {
-        final String invalidSignature = "Invalid signature as a string";
+        final String invalidSignature = "111222333444";
         final String stringToSign = "ユニコード文字列は署名します"; //using unicode to check UTF-8 encoding
 
-        when(mockSigner.isSignatureValid(stringToSign.getBytes("UTF-8"), invalidSignature.getBytes("UTF-8")))
+        when(mockSigner.isSignatureValid(stringToSign.getBytes("UTF-8"), Encoder.getBase64DecodedBytes(invalidSignature).get()))
                 .thenReturn(false);
 
         assertThat(stringSigner.isSignatureValid(stringToSign, invalidSignature), equalTo(false));


### PR DESCRIPTION
Sorry this was a mistake on my part, UTF-8 is not a valid format for the signature