### PR TITLE
should only log failure when signature cannot be verified

### DIFF
--- a/src/main/java/com/ft/membership/crypto/signature/Signer.java
+++ b/src/main/java/com/ft/membership/crypto/signature/Signer.java
@@ -118,20 +118,21 @@ public class Signer {
             throw new RuntimeException(e);
         }
 
-        boolean valid = false;
+        boolean isValid;
         try {
             ellipticCurveDSA.update(bytes);
-            valid = ellipticCurveDSA.verify(signature);
+            isValid = ellipticCurveDSA.verify(signature);
         } catch (SignatureException e) {
             resultOperation
                 .wasFailure()
                 .withDetail("signature_bytes", Encoder.getBase64EncodedString(bytes))
                 .throwingException(e)
                 .log();
+            return false;
         }
 
         resultOperation.wasSuccessful().log();
-        return valid;
+        return isValid;
     }
 
     private KeyPair createKeyPair(final String base64EncodedPublicKey,


### PR DESCRIPTION
The unit test testTamperedSignatureIsNotVerifiedSuccessfully confirms the behaviour.

https://github.com/Financial-Times/crypto-signatures/issues/5