### PR TITLE
Removed provider specific instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Example:
     StringVerifier verifier = new StringVerifier(publicKey);
     verifier.isSignatureValid(testString, signatureString)
 
+## Using the library in environments that doesn't provide SHA256withECDSA implementation (AWS Lambda)
+Add Bouncy Castle to the classpath:
+
+     org.bouncycastle:bcprov-jdk15on:1.54
+
+Dynamically register the provider:
+
+     java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+
+
 ## Developing crypto-signature
 
 Pull requests welcome!

--- a/src/main/java/com/ft/membership/crypto/signature/Config.java
+++ b/src/main/java/com/ft/membership/crypto/signature/Config.java
@@ -1,13 +1,8 @@
 package com.ft.membership.crypto.signature;
 
 public class Config {
-    private static final String SECURITY_PROVIDER = "SunEC";
     private static final String SIGNATURE_ALGORITHM = "SHA256withECDSA";
     private static final String KEY_ALGORITHM = "EC";
-
-    public static String getSecurityProvider() {
-        return SECURITY_PROVIDER;
-    }
 
     public static String getSignatureAlgorithm() {
         return SIGNATURE_ALGORITHM;

--- a/src/main/java/com/ft/membership/crypto/signature/Signer.java
+++ b/src/main/java/com/ft/membership/crypto/signature/Signer.java
@@ -59,9 +59,9 @@ public class Signer {
         Signature ellipticCurveDSA;
 
         try {
-            ellipticCurveDSA = Signature.getInstance(Config.getSignatureAlgorithm(), Config.getSecurityProvider());
+            ellipticCurveDSA = Signature.getInstance(Config.getSignatureAlgorithm());
             ellipticCurveDSA.initSign(privateKey);
-        } catch (NoSuchProviderException | NoSuchAlgorithmException | InvalidKeyException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             resultOperation.wasFailure().throwingException(e).log();
             throw new RuntimeException(e);
         }
@@ -84,10 +84,10 @@ public class Signer {
 
         final KeyFactory keyFactory;
         try {
-            keyFactory = KeyFactory.getInstance(Config.getKeyAlgorithm(), Config.getSecurityProvider());
+            keyFactory = KeyFactory.getInstance(Config.getKeyAlgorithm());
             PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
             return privateKey;
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeySpecException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/ft/membership/crypto/signature/Verifier.java
+++ b/src/main/java/com/ft/membership/crypto/signature/Verifier.java
@@ -60,9 +60,9 @@ public class Verifier {
         Signature ellipticCurveDSA;
 
         try {
-            ellipticCurveDSA = Signature.getInstance(Config.getSignatureAlgorithm(), Config.getSecurityProvider());
+            ellipticCurveDSA = Signature.getInstance(Config.getSignatureAlgorithm());
             ellipticCurveDSA.initVerify(publicKey);
-        } catch (NoSuchProviderException | NoSuchAlgorithmException | InvalidKeyException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             resultOperation.wasFailure().throwingException(e).log();
             throw new RuntimeException(e);
         }
@@ -91,10 +91,10 @@ public class Verifier {
 
         final KeyFactory keyFactory;
         try {
-            keyFactory = KeyFactory.getInstance(Config.getKeyAlgorithm(), Config.getSecurityProvider());
+            keyFactory = KeyFactory.getInstance(Config.getKeyAlgorithm());
             PublicKey publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
             return publicKey;
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeySpecException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
The actual security provider now depends on the order of preferred providers of the environment.
See: http://docs.oracle.com/javase/7/docs/technotes/guides/security/crypto/CryptoSpec.html#ProviderImplReq

This library can still be used with the default JDK providers, with no changes.
Using the library in environments where default JDK providers are absent (e.g. AWS Lambda) can be done adding the Bouncy Castle library to the classpath and dynamically registering the provider in the client code. See README