### PR TITLE
Prevent Noisy Logs

### DIFF
--- a/src/main/java/com/ft/membership/crypto/signature/Verifier.java
+++ b/src/main/java/com/ft/membership/crypto/signature/Verifier.java
@@ -3,7 +3,6 @@ package com.ft.membership.crypto.signature;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
@@ -75,7 +74,7 @@ public class Verifier {
             resultOperation
                     .wasFailure()
                     .withDetail("signature_bytes", Encoder.getBase64EncodedString(bytes))
-                    .throwingException(e)
+                    .withMessage(e.getMessage())
                     .log();
             return false;
         }


### PR DESCRIPTION
At the moment the whole stack is logged when signature validation fails. We only need the exception error message.